### PR TITLE
Temporary directory improvements

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,6 +5,7 @@
       "includePath": [
         "${workspaceFolder}/**",
         "${workspaceFolder}/bazel-ecsact-rtb/external/bazelregistry_docopt_cpp",
+        "${workspaceFolder}/bazel-ecsact-rtb/external/com_github_bazelboost_process/include",
         "${workspaceFolder}/bazel-bin/external/ecsact/parser2/_virtual_includes/parser2"
       ],
       "defines": [],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+    ],
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
     name = "com_grail_bazel_toolchain",
     strip_prefix = "bazel-toolchain-c78a67db025e967707febf04a60d57c2286d21ac",
     url = "https://github.com/yaxum62/bazel-toolchain/archive/c78a67db025e967707febf04a60d57c2286d21ac.tar.gz",

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -10,6 +10,7 @@ cc_binary(
 		"//find_cpp_compiler",
 		"//generate_files",
 		"//runtime_compile",
+		"//util:managed_temp_directory",
         "@ecsact//parser2",
 		"@bazelregistry_docopt_cpp//:docopt",
 		"@bazel_tools//tools/cpp/runfiles",

--- a/fetch_sources/fetch_sources.cc
+++ b/fetch_sources/fetch_sources.cc
@@ -15,8 +15,10 @@ result::fetch_sources ecsact::rtb::fetch_sources
 		return {};
 	}
 
-	auto base_dir = fs::temp_directory_path() / "ecsact-rtb" / "fetched_files";
-	std::cout << "Removing old fetched files...\n";
+	auto base_dir = options.temp_dir / "fetched_files";
+	if(fs::exists(base_dir)) {
+		std::cout << "Removing old fetched files...\n";
+	}
 	fs::remove_all(base_dir);
 	auto include_dir = base_dir / "include";
 	auto src_dir = base_dir / "src";

--- a/fetch_sources/fetch_sources.hh
+++ b/fetch_sources/fetch_sources.hh
@@ -8,6 +8,11 @@ namespace ecsact::rtb {
 	namespace options {
 		struct fetch_sources {
 			/**
+			 * Temporary directory fetch_sources may write to.
+			 */
+			std::filesystem::path temp_dir;
+
+			/**
 			 * If files are available as bazel runfiles attempt to get from them. May
 			 * be `nullptr`.
 			 */

--- a/generate_files/generate_files.cc
+++ b/generate_files/generate_files.cc
@@ -15,8 +15,10 @@ result::generate_files ecsact::rtb::generate_files
 	( const options::generate_files& options
 	)
 {
-	auto base_dir = fs::temp_directory_path() / "ecsact-rtb" / "generated_files";
-	std::cout << "Removing old generated files...\n";
+	auto base_dir = options.temp_dir / "generated_files";
+	if(fs::exists(base_dir)) {
+		std::cout << "Removing old generated files...\n";
+	}
 	fs::remove_all(base_dir);
 	auto include_dir = base_dir / "include";
 	auto src_dir = base_dir / "src";

--- a/generate_files/generate_files.hh
+++ b/generate_files/generate_files.hh
@@ -6,6 +6,10 @@
 namespace ecsact::rtb {
 	namespace options {
 		struct generate_files {
+			/**
+			 * Temporary directory generate_files may write to.
+			 */
+			std::filesystem::path temp_dir;
 			const ecsact::parse_results& parse_results;
 		};
 	}

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "managed_temp_directory",
+    srcs = ["managed_temp_directory.cc"],
+    hdrs = ["managed_temp_directory.hh"],
+    deps = [
+        "@boost//libs/process",
+    ],
+)

--- a/util/managed_temp_directory.cc
+++ b/util/managed_temp_directory.cc
@@ -1,0 +1,34 @@
+#include "managed_temp_directory.hh"
+
+#include <atomic>
+#include <string>
+#include <boost/process.hpp>
+
+namespace fs = std::filesystem;
+using ecsact::rtb::util::managed_temp_directory;
+
+static fs::path make_new_temp_path() {
+  constexpr auto prefix = "ecsat-rtb-";
+  static std::atomic_int last_id = 0;
+  int id = last_id++;
+  auto proc_id = boost::this_process::get_id();
+  auto temp_dir = fs::temp_directory_path();
+
+  auto new_dirname = (prefix + std::to_string(proc_id));
+
+  if(id == 0) {
+    return temp_dir / new_dirname;
+  } else {
+    return temp_dir / (new_dirname + "-" + std::to_string(id));
+  }
+}
+
+managed_temp_directory::managed_temp_directory()
+  : _path(make_new_temp_path())
+{
+  fs::create_directories(_path);
+}
+
+managed_temp_directory::~managed_temp_directory() {
+  fs::remove_all(_path);
+}

--- a/util/managed_temp_directory.hh
+++ b/util/managed_temp_directory.hh
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <filesystem>
+
+namespace ecsact::rtb::util {
+
+	/**
+	 * Temporary directory that automatically deletes itself upon destruction.
+	 */
+	class managed_temp_directory {
+		std::filesystem::path _path;
+	public:
+		managed_temp_directory();
+		~managed_temp_directory();
+
+		inline std::filesystem::path path() const noexcept {
+			return _path;
+		}
+
+		inline operator std::filesystem::path() const noexcept {
+			return _path;
+		}
+	};
+
+}


### PR DESCRIPTION
 - [x] Using unique temporary directory instead of a hard coded one. Allows for multiple instances of the runtime builder to not conflict with each other.
 - [x] Added option to specify the temp directory if you have specific needs for your hard drive.